### PR TITLE
Docker for development and schema as volume

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+node_modules
+build
+dist

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,10 @@
+# Stage 0, "run-stage".
+FROM node:lts
+WORKDIR /app
+COPY package*.json /app/
+
+# First install deps, then copy app and build.
+RUN npm install
+COPY ./ /app/
+
+ENTRYPOINT [ "npm", "start" ]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,37 @@
 # Form PA
 
 ![Screen](public/images/screen.png "Screen")
+
+## Generate a valid JSON Schema
+Using [this](https://jsonschema.net) service or any others found on internet create a simple JSON schema results a quite easy operation to do.
+
+## Run
+
+### Local Dev
+Install all dependencies and start
+```bash
+$ npm install
+$ npm start
+```
+
+### Local Prod
+Install all dependencies and build
+```bash
+$ npm install
+$ npm build
+```
+Then `./dist` will be ready to be served.
+
+
+### Docker
+Run with a preset json schema, stored in `src/schema.json`
+```bash
+$ docker build . -t form-pa
+$ docker run form-pa
+```
+
+Or simply run docker replacing that schema with one supplied at runtime as:
+```bash
+$ docker build -f Dockerfile.dev . form-pa:dev
+$ docker run -v ${PWD}/schema.json.example:/app/src/schema.json -it -rm -p 3000:3000 form-pa
+```

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ Then `./dist` will be ready to be served.
 Run with a preset json schema, stored in `src/schema.json`
 ```bash
 $ docker build . -t form-pa
-$ docker run form-pa
+$ docker run -it --rm form-pa
 ```
 
 Or simply run docker replacing that schema with one supplied at runtime as:
 ```bash
 $ docker build -f Dockerfile.dev . form-pa:dev
-$ docker run -v ${PWD}/schema.json.example:/app/src/schema.json -it -rm -p 3000:3000 form-pa
+$ docker run -v ${PWD}/schema.json.example:/app/src/schema.json -it --rm -p 3000:3000 form-pa
 ```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,14 @@
+version: '3.2'
+services:
+
+  # Form PA
+  form-pa:
+    container_name: form-pa
+    image: sebbalex/form-pa
+    build:
+      context: ./
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    stdin_open: true
+    tty: true

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "@types/react": "16.9.35",
     "@types/react-dom": "16.9.8",
     "react-scripts": "^3.4.1",
-    "jest": "^26.0.1",
     "ts-jest": "^26.0.0",
     "typescript": "3.9.3"
   },

--- a/schema.json.example
+++ b/schema.json.example
@@ -1,0 +1,76 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "http://example.com/example.json",
+    "type": "object",
+    "title": "The root schema",
+    "description": "The root schema comprises the entire JSON document.",
+    "default": {},
+    "examples": [
+        {
+            "name": "A green door",
+            "price": 12.5,
+            "tags": [
+                "home",
+                "green"
+            ]
+        }
+    ],
+    "required": [
+        "name",
+        "price",
+        "tags"
+    ],
+    "additionalProperties": true,
+    "properties": {
+        "name": {
+            "$id": "#/properties/name",
+            "type": "string",
+            "title": "The name schema",
+            "description": "An explanation about the purpose of this instance.",
+            "default": "",
+            "examples": [
+                "A green door"
+            ]
+        },
+        "price": {
+            "$id": "#/properties/price",
+            "type": "number",
+            "title": "The price schema",
+            "description": "An explanation about the purpose of this instance.",
+            "default": 0.0,
+            "examples": [
+                12.5
+            ]
+        },
+        "tags": {
+            "$id": "#/properties/tags",
+            "type": "array",
+            "title": "The tags schema",
+            "description": "An explanation about the purpose of this instance.",
+            "default": [],
+            "examples": [
+                [
+                    "home",
+                    "green"
+                ]
+            ],
+            "additionalItems": true,
+            "items": {
+                "anyOf": [
+                    {
+                        "$id": "#/properties/tags/items/anyOf/0",
+                        "type": "string",
+                        "title": "The first anyOf schema",
+                        "description": "An explanation about the purpose of this instance.",
+                        "default": "",
+                        "examples": [
+                            "home",
+                            "green"
+                        ]
+                    }
+                ],
+                "$id": "#/properties/tags/items"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Using `Dockerfile.dev` configuration it can be possible to pass at docker runtime the schema on which form will be generated. This is extremely useful to test new schema and as zeroconf dev environment.